### PR TITLE
[BCT-4378] Fixes PHP error on WordPress 5.7

### DIFF
--- a/includes/class-canvas.php
+++ b/includes/class-canvas.php
@@ -56,20 +56,20 @@ if ( ! class_exists( 'Tailor_Canvas' ) ) {
             add_action( 'wp_head', array( $this, 'canvas_head' ) );
 	        add_filter( 'the_content', array( $this, 'canvas_content' ), -1 );
 	        add_action( 'wp_footer', array( $this, 'canvas_footer' ) );
-	        
+
             add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
             add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-	        
+
             add_action( 'tailor_canvas_footer', array( $this, 'print_templates' ) );
         }
 
 	    /**
 	     * Adds a custom body class to the preview window.
-	     * 
+	     *
 	     * @since 1.7.0
-	     * 
+	     *
 	     * @param $classes
-	     * 
+	     *
 	     * @return $classes
 	     */
 	    public function add_body_class( $classes ) {
@@ -148,7 +148,7 @@ if ( ! class_exists( 'Tailor_Canvas' ) ) {
          * @since 1.0.0
          */
         public function enqueue_styles() {
-	        
+
 	        if ( apply_filters( 'tailor_enable_canvas_styles', true ) && ! did_action( 'tailor_enqueue_canvas_styles' ) ) {
 		        $handle = 'tailor-canvas-styles';
 		        $min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
@@ -199,9 +199,9 @@ if ( ! class_exists( 'Tailor_Canvas' ) ) {
 		        $allowed_urls[] = home_url( '/', 'https' );
 	        }
 
-			wp_localize_script( $handle, 'ajaxurl', array(
-				esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) )
-			) );
+	        wp_localize_script( $handle, 'ajaxurl', array(
+	            esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) )
+	        ) );
 
 	        wp_localize_script( $handle, '_urls', array(
 		        'ajax'              =>  esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) ),
@@ -280,7 +280,7 @@ if ( ! class_exists( 'Tailor_Canvas' ) ) {
 	     */
 	    function print_templates() {
 		    tailor_partial( 'underscore/canvas', 'tools' );
-		    
+
 		    tailor_partial( 'underscore/element', 'empty' );
 	    }
     }

--- a/includes/class-canvas.php
+++ b/includes/class-canvas.php
@@ -199,7 +199,9 @@ if ( ! class_exists( 'Tailor_Canvas' ) ) {
 		        $allowed_urls[] = home_url( '/', 'https' );
 	        }
 
-	        wp_localize_script( $handle, 'ajaxurl', esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) ) );
+			wp_localize_script( $handle, 'ajaxurl', array(
+				esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) )
+			) );
 
 	        wp_localize_script( $handle, '_urls', array(
 		        'ajax'              =>  esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) ),

--- a/includes/class-sidebar.php
+++ b/includes/class-sidebar.php
@@ -272,8 +272,8 @@ if ( ! class_exists( 'Tailor_Sidebar' ) ) {
 	        ) );
 
 	        wp_localize_script( $handle, 'ajaxurl', array(
-				esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) )
-			) );
+		        esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) )
+	        ) );
 
 	        wp_localize_script( $handle, '_urls', array(
 		        'ajax'              =>  esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) ),

--- a/includes/class-sidebar.php
+++ b/includes/class-sidebar.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'Tailor_Sidebar' ) ) {
             if ( ! tailor()->is_tailoring() ) {
                 return;
             }
-	        
+
 	        $this->add_actions();
         }
 
@@ -40,10 +40,10 @@ if ( ! class_exists( 'Tailor_Sidebar' ) ) {
          * @access protected
          */
         protected function add_actions() {
-	        
+
 	        /**
 	         * Fires before the sidebar is initialized.
-	         * 
+	         *
 	         * @since 1.3.4
 	         */
 	        do_action( 'tailor_sidebar_init' );
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Tailor_Sidebar' ) ) {
 
             add_action( 'wp_ajax_tailor_refresh_nonces', array( $this, 'refresh_nonces' ) );
         }
-	    
+
 	    /**
 	     * Renders a blank page.
 	     *
@@ -83,7 +83,7 @@ if ( ! class_exists( 'Tailor_Sidebar' ) ) {
 	        if ( is_customize_preview() ) {
 		        return $template;
 	        }
-	        
+
 	        if ( ! tailor()->check_user_role() || ! tailor()->check_post() ) {
 	            return $template;
 	        }
@@ -201,7 +201,7 @@ if ( ! class_exists( 'Tailor_Sidebar' ) ) {
 	        tailor_partial( 'underscore/sidebar', 'home' );
 	        tailor_partial( 'underscore/sidebar', 'home-empty' );
         }
-	    
+
         /**
          * Enqueues styles for the Tailor Sidebar.
          *
@@ -271,7 +271,9 @@ if ( ! class_exists( 'Tailor_Sidebar' ) ) {
 		        'type'              =>  $post_type,
 	        ) );
 
-	        wp_localize_script( $handle, 'ajaxurl', esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) ) );
+	        wp_localize_script( $handle, 'ajaxurl', array(
+				esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) )
+			) );
 
 	        wp_localize_script( $handle, '_urls', array(
 		        'ajax'              =>  esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) ),


### PR DESCRIPTION
## Updates

* The third parameter of the `wp_localize_script` expects an array, and so WordPress in debug mode now yells at you inside the Tailor editing experience, this fixes that